### PR TITLE
Fix code block contrast in posts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,15 @@ export default defineConfig({
       filter: (page) => !page.includes('/404'),
     }),
   ],
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark',
+      },
+      wrap: false,
+    },
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,3 +135,35 @@
     border-top: 1px solid var(--border);
   }
 }
+
+@layer utilities {
+  .prose pre {
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    overflow-x: auto;
+  }
+  .prose pre code {
+    background: transparent !important;
+    padding: 0 !important;
+    color: inherit !important;
+    font-size: inherit !important;
+    border-radius: 0 !important;
+  }
+  .prose pre code::before,
+  .prose pre code::after {
+    content: none !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .astro-code,
+    .astro-code span {
+      color: var(--shiki-dark) !important;
+      background-color: var(--shiki-dark-bg) !important;
+      font-style: var(--shiki-dark-font-style) !important;
+      font-weight: var(--shiki-dark-font-weight) !important;
+      text-decoration: var(--shiki-dark-text-decoration) !important;
+    }
+  }
+}


### PR DESCRIPTION
Prose's inline-code styling was bleeding into block code inside <pre>, painting a dark background and forcing a dark text color over Shiki's already-dark theme — effectively invisible in dark mode. Also configures dual Shiki themes (github-light / github-dark) so code blocks respect prefers-color-scheme instead of rendering dark-only.

- Add markdown.shikiConfig.themes to astro.config.mjs
- Reset prose pre > code overrides in global.css
- Apply --shiki-dark vars under prefers-color-scheme: dark