### PR TITLE
feat(ui): editorial UI/UX overhaul — typography, animations, about, contact

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -31,10 +31,16 @@ const heightClass =
 
 const titleClass =
   size === 'cover'
-    ? 'text-4xl md:text-6xl'
+    ? 'text-5xl md:text-7xl'
     : size === 'post'
       ? 'text-3xl md:text-5xl'
       : 'text-3xl md:text-4xl';
+
+const fontClass =
+  size === 'cover' ? 'font-display' : 'font-serif';
+
+const trackingClass =
+  size === 'cover' ? 'tracking-[-0.02em]' : 'tracking-tight';
 
 const padClass =
   size === 'cover'
@@ -55,11 +61,7 @@ const padClass =
     decoding="async"
     class="absolute inset-0 -z-10 size-full object-cover"
   />
-  <div
-    class="absolute inset-0 -z-10"
-    style="background: linear-gradient(180deg, rgba(2, 6, 23, 0.15) 0%, rgba(2, 6, 23, 0.45) 45%, rgba(2, 6, 23, 0.78) 100%);"
-  >
-  </div>
+  <div class="hero-gradient absolute inset-0 -z-10"></div>
 
   <div class:list={['container-wide flex h-full flex-col justify-end', padClass]}>
     {eyebrow && (
@@ -67,7 +69,7 @@ const padClass =
         {eyebrow}
       </p>
     )}
-    <h1 class:list={['font-serif font-semibold leading-[1.05] tracking-tight drop-shadow-sm', titleClass]}>
+    <h1 class:list={[fontClass, 'font-semibold leading-[1.05] drop-shadow-sm', trackingClass, titleClass]}>
       {title}
     </h1>
     {subtitle && (

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,7 +11,7 @@ const path = Astro.url.pathname.replace(/\/$/, '') || '/';
   >
     <a
       href="/"
-      class="font-serif text-lg font-semibold tracking-tight no-underline"
+      class="font-display text-lg font-semibold tracking-[-0.02em] no-underline"
       aria-label={`${SITE.title} — home`}
     >
       {SITE.title}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,7 +7,7 @@ export const SITE = {
   author: {
     name: 'Miguel Escalante',
     email: 'escalas5@gmail.com',
-    location: 'Mexico City, Mexico',
+    location: 'San Salvador, El Salvador',
     twitter: 'Skalas',
     github: 'Skalas',
     linkedin: 'skalas',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,7 +42,7 @@ const props = Astro.props;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=JetBrains+Mono:wght@400;500&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=swap"
     />
 
     <SEO {...props} />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -122,10 +122,10 @@ const readingMeta = [
           <li class="flex-1">
             <a href={`/${prev.slug}`} class="block no-underline group">
               <span class="block text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-                ← Previous
+                Previous
               </span>
-              <span class="mt-1 block font-serif text-lg group-hover:text-[color:var(--link)]">
-                {prev.title}
+              <span class="mt-1 block font-serif text-lg transition-colors duration-200 group-hover:text-[color:var(--link)]">
+                <span aria-hidden="true" class="mr-1 inline-block translate-x-0 opacity-0 transition-all duration-200 ease-out group-hover:-translate-x-1 group-hover:opacity-100">←</span>{prev.title}
               </span>
             </a>
           </li>
@@ -134,10 +134,10 @@ const readingMeta = [
           <li class="flex-1 sm:text-right">
             <a href={`/${next.slug}`} class="block no-underline group">
               <span class="block text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-                Next →
+                Next
               </span>
-              <span class="mt-1 block font-serif text-lg group-hover:text-[color:var(--link)]">
-                {next.title}
+              <span class="mt-1 block font-serif text-lg transition-colors duration-200 group-hover:text-[color:var(--link)]">
+                {next.title}<span aria-hidden="true" class="ml-1 inline-block -translate-x-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100">→</span>
               </span>
             </a>
           </li>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,59 +1,187 @@
 ---
-import PageLayout from '../layouts/PageLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Hero from '../components/Hero.astro';
 import aboutBg from '../assets/heroes/about-bg.jpg';
 ---
 
-<PageLayout
+<BaseLayout
   title="About"
-  description="Miguel Escalante — data scientist, mathematician, and developer based in Mexico City."
-  hero={aboutBg}
-  heroAlt="Abstract mountain landscape"
+  description="Miguel Escalante — data scientist, AI consultant, and engineer based in San Salvador."
   image={aboutBg.src}
+  imageWidth={aboutBg.width}
+  imageHeight={aboutBg.height}
+  imageAlt="Abstract mountain landscape"
 >
-  <p>
-    Miguel is a Mexican data scientist. Since the beginning of his career — working for the police force in Mexico
-    City — data analysis has been his day job, guiding him to discover useful information, suggest conclusions, and
-    support decision-making.
-  </p>
+  <Hero
+    size="page"
+    title="About"
+    image={aboutBg}
+    imageAlt="Abstract mountain landscape"
+  />
 
-  <p>
-    He holds a BS in Applied Mathematics and an MSc in Data Science, both from ITAM, one of Mexico's top think
-    tanks and higher education institutions. At ITAM, Miguel developed a genuine interest in applying
-    mathematical methods to the dynamic complexity of socioeconomic phenomena. Over the past several years, he
-    has worked with both private and public institutions with one clear objective: designing data-driven
-    solutions that improve decision-making processes constantly challenged by lack of information.
-  </p>
+  <div class="container-prose py-16">
 
-  <p>
-    At the Center of Attention to Emergencies and Citizen Protection of Mexico City, Miguel applied his data
-    skills to increase the efficiency of crime prediction, evaluate police officers on a weekly basis, and
-    design solutions to improve their performance. He also helped design the structure that handled the entire
-    analysis pipeline assembling the predictions and the evaluations.
-  </p>
+    <section class="mb-14">
+      <p class="font-serif text-xl leading-relaxed">
+        I'm a data scientist and engineer. The work started in 2010 — crime prediction models
+        for the Mexico City police, everything running through Excel macros and Matlab — and
+        has gone through government, startups, consulting, and public-sector AI since then.
+        The common thread is building things that ship and getting organizations to act on
+        what the data says. Currently leading AI strategy for the Government of El Salvador,
+        based in San Salvador.
+      </p>
+      <p class="mt-4 font-serif text-lg leading-relaxed text-[color:var(--text-muted)]">
+        Applied Mathematics undergrad, Data Science M.Sc. — both at ITAM in Mexico City.
+        I taught there for four years while working full-time.
+        The career posts cover the longer version.
+      </p>
+    </section>
 
-  <p>
-    His experience with Mexico City's government led him to OPI Analytics, where he designed and managed the
-    infrastructure for the whole company — AWS, Docker, R, Ruby and Python — and helped develop data pipelines
-    for a wide variety of public databases. After that, he consulted with Globant for a large textile company,
-    helping optimize how clothes were shipped to stores via optimal decision-making.
-  </p>
+    <section>
+      <h2 class="mb-8 font-sans text-sm uppercase tracking-[0.25em] text-[color:var(--text-muted)]">
+        Career
+      </h2>
 
-  <p>
-    Miguel was later Data Science Manager at Cultura Colectiva, a Mexican startup focused on understanding the
-    best way to communicate with people. With data analytics and artificial intelligence, Cultura Colectiva
-    became one of the most valued media companies in Latin America. Miguel built the first version of the
-    startup's AI tooling and grew it into something more powerful and diverse.
-  </p>
+      <div class="timeline">
 
-  <p>
-    Miguel also applied these skills during <b>#Verificado19S</b>, a digital platform that verified and organized
-    information to create a more efficient response for citizens after the September 19th earthquake in Mexico.
-    Miguel coordinated the technological and data side of the effort — work that made a significant impact on
-    how people saw both millennials and social networks.
-  </p>
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2024 — Present</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">AI Lead Consultant</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Government of El Salvador</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            AI strategy across healthcare (DoctorSV), education reform, and government services.
+            5G network optimization under USAID and EU-funded engagements. The work is less
+            about any one model and more about which levers actually exist inside large public
+            institutions — and whether you can move them.
+          </p>
+        </div>
 
-  <p>
-    Miguel lives in Mexico City and enjoys photography, hiking, biking, and driving around the country. On his
-    free time you can spot him in a local mezcalería, or dancing salsa.
-  </p>
-</PageLayout>
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2022 — 2024</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Staff Software Engineer</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Kavak</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            Led the Data Engineering team — pipelines, cloud infrastructure, the work that
+            keeps analytics functional when the company is operating across multiple countries.
+            The engineering constraints were real.
+          </p>
+        </div>
+
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2018 — 2022</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Software Designer / Data Scientist</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Globant</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            Computer Vision, NLP, Anomaly Detection — different clients, different industries.
+            Mentored the Mexico data science team. Consulting means being useful to an
+            organization you don't fully understand yet. That skill transfers.
+          </p>
+        </div>
+
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2016 — 2018</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Data Science Manager</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Cultura Colectiva</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            Built the data science team from scratch. We were doing content evaluation and
+            generation work before any of the current tooling existed — the hard way. Most of
+            the company's BI ran through the team. In September 2017 the same team pivoted to
+            build <strong>Verificado19s</strong>, a real-time data verification platform for
+            the Mexico City earthquake. It's still the most important thing I've worked on,
+            and it isn't close.
+          </p>
+        </div>
+
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2016</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Data Science Lead — Data Lab</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Presidency of Mexico — Open Data Initiative</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            A centralized team inside the federal government: find the problem, build the
+            solution, ship it. Cloud infrastructure for analytical workloads across multiple
+            agencies. Short stint, real work.
+          </p>
+        </div>
+
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2015 — 2016</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Data Scientist / Data Engineer</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Globant · OPI Analytics</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            Distribution optimization at Globant — tight constraints, real money, discrete
+            math, no neural nets. At OPI, full-picture startup engineering: Docker when it
+            was still raw, cloud ops, Ruby, Node, Mongo, Postgres, the whole pipeline from
+            nothing to shipped.
+          </p>
+        </div>
+
+        <div class="timeline-entry">
+          <p class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">2010 — 2015</p>
+          <h3 class="mt-1 font-serif text-xl font-semibold">Data Analyst</h3>
+          <p class="mt-0.5 font-sans text-sm font-medium text-[color:var(--link)]">Center for Emergency Attention and Citizen Protection, Mexico City</p>
+          <p class="mt-2 font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+            First job out of university. Crime prediction models, weekly officer evaluations,
+            a pipeline that ran through Excel macros and Matlab. The math was the easy part.
+            Designing something a commander could act on at 6am — that was the job.
+          </p>
+        </div>
+
+      </div>
+    </section>
+
+    <section class="border-t border-[color:var(--border)] pt-12">
+      <h2 class="mb-6 font-sans text-sm uppercase tracking-[0.25em] text-[color:var(--text-muted)]">
+        Teaching
+      </h2>
+      <p class="font-sans text-sm text-[color:var(--text-muted)]">ITAM · 2020–2024</p>
+      <ul class="mt-3 space-y-1 font-serif text-base text-[color:var(--text-muted)]">
+        <li>NoSQL for Data Science (M.Sc.)</li>
+        <li>Introduction to Programming for Data Science (M.Sc.)</li>
+        <li>Applied Analysis in Computational Mathematics</li>
+      </ul>
+    </section>
+
+    <section class="mt-12 border-t border-[color:var(--border)] pt-12">
+      <h2 class="mb-6 font-sans text-sm uppercase tracking-[0.25em] text-[color:var(--text-muted)]">
+        Selected Publications
+      </h2>
+      <ul class="space-y-4">
+        {[
+          {
+            year: '2019',
+            citation: 'Esquinca, Escalante et al. ',
+            title: 'Recomendaciones para Sociedad Civil',
+            venue: 'Google Play Store.',
+          },
+          {
+            year: '2016',
+            citation: 'Martinez, Escalante, Beguerisse-Díaz et al. ',
+            title: 'Understanding Human Behavior in Urban Spaces',
+            venue: 'IJWSR.',
+          },
+          {
+            year: '2013',
+            citation: 'Prieto, Escalante et al. ',
+            title: 'Análisis Criminal y Uso de Cámaras de Seguridad en la CDMX',
+            venue: 'Buenas Prácticas para el Análisis Delictual en América Latina.',
+          },
+        ].map(({ year, citation, title, venue }) => (
+          <li class="grid grid-cols-[3.5rem_1fr] gap-4 font-serif text-base">
+            <span class="font-sans text-xs text-[color:var(--text-muted)] pt-0.5">{year}</span>
+            <span class="text-[color:var(--text-muted)]">
+              {citation}<em class="text-[color:var(--text)]">{title}</em>. {venue}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="mt-12 border-t border-[color:var(--border)] pt-12">
+      <p class="font-serif text-base leading-relaxed text-[color:var(--text-muted)]">
+        San Salvador now, Mexico City before that. Trail, camera, mezcalería.
+        I'm easier to reach by <a href="mailto:escalas5@gmail.com">email</a> than through any form.
+      </p>
+    </section>
+
+  </div>
+</BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,46 +1,89 @@
 ---
-import PageLayout from '../layouts/PageLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Hero from '../components/Hero.astro';
 import contactBg from '../assets/heroes/contact-bg.jpg';
 import { SITE, SOCIAL_LINKS } from '../consts';
 
 const mailto = `mailto:${SITE.author.email}?subject=${encodeURIComponent('Hello from skalas.me')}`;
 ---
 
-<PageLayout
+<BaseLayout
   title="Contact"
   description="Get in touch with Miguel Escalante."
-  hero={contactBg}
-  heroAlt="Abstract cityscape"
   image={contactBg.src}
+  imageWidth={contactBg.width}
+  imageHeight={contactBg.height}
+  imageAlt="Abstract cityscape"
 >
-  <p>
-    The fastest way to reach me is email. I read everything, and I reply to most things — though sometimes
-    slowly.
-  </p>
+  <Hero
+    size="page"
+    title="Contact"
+    image={contactBg}
+    imageAlt="Abstract cityscape"
+  />
 
-  <p class="not-prose my-10">
-    <a
-      href={mailto}
-      class="inline-flex items-center gap-3 rounded-md border border-[color:var(--border)] bg-[color:var(--link)] px-6 py-4 font-sans text-base font-medium text-white no-underline transition-colors hover:bg-[color:var(--link-hover)]"
-    >
-      <span aria-hidden="true">✉</span>
-      <span>{SITE.author.email}</span>
-    </a>
-  </p>
+  <div class="container-prose py-16">
 
-  <p>Or find me on any of these:</p>
+    <section class="mb-14">
+      <p class="font-serif text-xl leading-relaxed">
+        Email is fastest. I read everything, and I reply to most things — though sometimes slowly.
+      </p>
 
-  <ul>
-    {
-      SOCIAL_LINKS.map(({ label, href, rel }) => (
-        <li>
-          <a href={href} rel={rel}>{label}</a>
-        </li>
-      ))
-    }
-  </ul>
+      <a
+        href={mailto}
+        class="group mt-10 inline-flex items-center gap-3 no-underline"
+        aria-label={`Send email to ${SITE.author.email}`}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-6 shrink-0 text-[color:var(--text-muted)] transition-colors duration-200 group-hover:text-[color:var(--link)]"
+          aria-hidden="true"
+        >
+          <rect width="20" height="16" x="2" y="4" rx="2"/>
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+        </svg>
+        <span class="font-serif text-2xl font-semibold transition-colors duration-200 group-hover:text-[color:var(--link)] md:text-3xl">
+          {SITE.author.email}
+        </span>
+        <span
+          aria-hidden="true"
+          class="-translate-x-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100"
+        >→</span>
+      </a>
+    </section>
 
-  <p class="text-sm text-[color:var(--text-muted)]">
-    Based in {SITE.author.location}. Timezone: {SITE.timezone}.
-  </p>
-</PageLayout>
+    <section class="border-t border-[color:var(--border)] pt-12">
+      <p class="mb-6 font-sans text-sm uppercase tracking-[0.25em] text-[color:var(--text-muted)]">
+        Elsewhere
+      </p>
+      <ul class="flex flex-wrap gap-3" role="list">
+        {
+          SOCIAL_LINKS.map(({ label, href, rel }) => (
+            <li>
+              <a
+                href={href}
+                rel={rel}
+                class="inline-block rounded-full border border-[color:var(--border)] px-4 py-2 font-sans text-sm no-underline text-[color:var(--text-muted)] transition-colors duration-200 hover:border-[color:var(--link)] hover:text-[color:var(--link)]"
+              >
+                {label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="mt-12 border-t border-[color:var(--border)] pt-8">
+      <p class="font-sans text-sm text-[color:var(--text-muted)]">
+        {SITE.author.location}.
+      </p>
+    </section>
+
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const posts = (await getCollection('posts', ({ data }) => !data.draft)).sort(
       </h2>
       <a
         href="/feed.xml"
-        class="text-sm no-underline text-[color:var(--text-muted)] hover:text-[color:var(--link)]"
+        class="rounded-full border border-[color:var(--border)] px-3 py-1 text-xs no-underline text-[color:var(--text-muted)] transition-colors duration-200 hover:border-[color:var(--link)] hover:text-[color:var(--link)]"
       >
         RSS
       </a>
@@ -43,16 +43,24 @@ const posts = (await getCollection('posts', ({ data }) => !data.draft)).sort(
 
     <ol class="space-y-12">
       {
-        posts.map((post) => (
-          <li>
+        posts.map((post, index) => (
+          <li
+            class="fade-up-item"
+            style={`transition-delay: ${index * 70}ms`}
+            data-animate
+          >
             <article class="group grid gap-2 md:grid-cols-[10rem_1fr]">
               <div class="font-sans text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)] md:pt-2">
                 <FormattedDate date={post.data.date} />
               </div>
               <div>
                 <a href={`/${post.id}`} class="no-underline">
-                  <h3 class="font-serif text-2xl font-semibold leading-tight transition-colors group-hover:text-[color:var(--link)] md:text-3xl">
+                  <h3 class="font-serif text-2xl font-semibold leading-tight text-[color:var(--text)] transition-colors duration-200 group-hover:text-[color:var(--link)] md:text-3xl">
                     {post.data.title}
+                    <span
+                      aria-hidden="true"
+                      class="ml-1.5 inline-block -translate-x-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100"
+                    >→</span>
                   </h3>
                 </a>
                 {post.data.description && (
@@ -61,8 +69,8 @@ const posts = (await getCollection('posts', ({ data }) => !data.draft)).sort(
                   </p>
                 )}
                 {post.data.category && (
-                  <p class="mt-3 text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">
-                    {post.data.category}
+                  <p class="mt-3">
+                    <span class="category-pill">{post.data.category}</span>
                   </p>
                 )}
               </div>
@@ -73,3 +81,30 @@ const posts = (await getCollection('posts', ({ data }) => !data.draft)).sort(
     </ol>
   </section>
 </BaseLayout>
+
+<script>
+  const items = document.querySelectorAll<HTMLElement>('[data-animate]');
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          (entry.target as HTMLElement).classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+  );
+
+  items.forEach((el) => {
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight) {
+      el.style.transitionDuration = '0s';
+      el.classList.add('is-visible');
+      requestAnimationFrame(() => el.style.removeProperty('transition-duration'));
+    } else {
+      observer.observe(el);
+    }
+  });
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-serif: "Source Serif 4", "Source Serif Pro", ui-serif, Georgia, "Times New Roman", serif;
+  --font-display: "Playfair Display", ui-serif, Georgia, "Times New Roman", serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 
   --color-ink-50:  #f8fafc;
@@ -133,6 +134,76 @@
 
   .hairline {
     border-top: 1px solid var(--border);
+  }
+
+  .hero-gradient {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-ink-950) 12%, transparent) 0%,
+      color-mix(in srgb, var(--color-ink-950) 42%, transparent) 45%,
+      color-mix(in srgb, var(--color-ink-950) 80%, transparent) 100%
+    );
+  }
+
+  .fade-up-item {
+    opacity: 0;
+    transform: translateY(1.25rem);
+    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  }
+  .fade-up-item.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .category-pill {
+    display: inline-block;
+    font-family: var(--font-sans);
+    font-size: 0.65rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.2rem 0.65rem;
+    border-radius: 9999px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    transition: border-color 200ms ease-out, color 200ms ease-out;
+  }
+  .group:hover .category-pill {
+    border-color: var(--link);
+    color: var(--link);
+  }
+
+  .timeline {
+    position: relative;
+    padding-left: 1.5rem;
+  }
+  .timeline::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.5rem;
+    bottom: 0;
+    width: 1px;
+    background: var(--border);
+  }
+  .timeline-entry {
+    position: relative;
+    padding-bottom: 2.5rem;
+  }
+  .timeline-entry::before {
+    content: '';
+    position: absolute;
+    left: calc(-1.5rem - 4px);
+    top: 0.4rem;
+    width: 9px;
+    height: 9px;
+    border-radius: 9999px;
+    border: 2px solid var(--link);
+    background: var(--bg);
+    transition: background-color 200ms ease-out;
+  }
+  .timeline-entry:hover::before {
+    background: var(--link);
   }
 }
 


### PR DESCRIPTION
## Summary

- **Typography**: adds Playfair Display as display font; cover hero title and nav logo use it at `text-5xl/7xl` with tight tracking
- **Animations**: post list items fade up on scroll via IntersectionObserver (70ms stagger); `→` / `←` arrows reveal on hover across post list and prev/next navigation
- **Design tokens**: `hero-gradient` (CSS `color-mix`), `fade-up-item`, `category-pill`, and `timeline` utilities added to global CSS; hardcoded inline overlay replaced
- **About page**: full rewrite — first-person editorial voice, 7-entry career timeline (2010–present), teaching section, publications, location updated to San Salvador
- **Contact page**: drops prose wrapper and app-style button; email address is the display element with SVG icon and hover arrow; social links as pills
- **Nav logo**: `font-serif` → `font-display` for brand consistency with hero
- **consts.ts**: location updated to San Salvador, El Salvador

## Pre-Landing Review

No critical issues.
- `color-mix(in srgb)` not supported in Safari < 16.2 — cosmetic fallback only (hero overlay absent on very old browsers)
- `calc(-1.5rem - 4px)` mixed units in timeline CSS — intentional positioning

## Tests

- [x] No test runner configured (static Astro site)
- [x] `astro build` passes — 7 pages built, 0 errors

---
Generated with [Claude Code](https://claude.ai/code)